### PR TITLE
feat: improve expiry date picker by enforcing future dates and 7-day default.

### DIFF
--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -36,19 +36,21 @@ class _AddItemScreenState extends State<AddItemScreen> {
 
   // Helper to show the date picker
   Future<void> _selectExpiryDate() async {
-    final DateTime? pickedDate = await showDatePicker(
+    final now = DateTime.now();
+    final tomorrow = now.add(const Duration(days: 1));
+
+    final pickedDate = await showDatePicker(
       context: context,
-      initialDate: _selectedExpiryDate ?? DateTime.now().add(const Duration(days: 7)),
-      firstDate: DateTime.now(),
-      lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
+      initialDate: _selectedExpiryDate ?? now.add(const Duration(days: 7)),
+      firstDate: tomorrow,
+      lastDate: now.add(const Duration(days: 365 * 5)),
     );
 
-    if (pickedDate != null) {
-      setState(() {
-        _selectedExpiryDate = pickedDate;
-      });
-    }
+    if (pickedDate == null) return;
+
+    setState(() => _selectedExpiryDate = pickedDate);
   }
+
 
   // Pick image from gallery
   Future<void> _pickImage() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -529,10 +529,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
- Updated the expiry date picker to prevent selecting today or past dates by setting the minimum selectable date to tomorrow.
- Pre-selected the expiry date to 7 days from today to improve data entry speed and align with typical grocery shelf life.
- Changes applied in add_item_screen.dart.